### PR TITLE
feat(services): Implementa a funcionalidade de gestão de serviços (Listar e Cadastrar)

### DIFF
--- a/backend/api/serializers.py
+++ b/backend/api/serializers.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 from .models import User, Service, Appointment
 from datetime import timedelta  
 from django.core.exceptions import ValidationError
+from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 
 
 class UserSerializer(serializers.ModelSerializer):
@@ -151,3 +152,12 @@ class AppointmentSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         validated_data['status'] = Appointment.Status.RESERVED
         return super().create(validated_data)
+
+class MyTokenObtainPairSerializer(TokenObtainPairSerializer):
+    @classmethod
+    def get_token(cls, user):
+        token = super().get_token(user)
+        token['username'] = user.username
+        token['role'] = user.role
+
+        return token

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -119,9 +119,9 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/5.2/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = 'pt-br'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'America/Sao_Paulo'
 
 USE_I18N = True
 

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
 from pathlib import Path
+from datetime import timedelta
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -42,7 +43,7 @@ INSTALLED_APPS = [
     'corsheaders', # CORS
     'api',
     'drf_yasg',
-    'django_extensions',  # com underline
+    'django_extensions',
 ]
 
 MIDDLEWARE = [
@@ -150,3 +151,10 @@ else:
     CORS_ALLOWED_ORIGINS = [
         "https://www.sasbapp.com.br",
     ]
+
+# Configurações do Simple JWT
+SIMPLE_JWT = {
+    "ACCESS_TOKEN_LIFETIME": timedelta(minutes=10),
+    "REFRESH_TOKEN_LIFETIME": timedelta(minutes=60),
+    "TOKEN_OBTAIN_SERIALIZER": "api.serializers.MyTokenObtainPairSerializer",
+}

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -7,15 +7,51 @@ const apiClient = axios.create({
 apiClient.interceptors.request.use(
   (config) => {
     const token = localStorage.getItem('accessToken');
-
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }
-
     return config;
   },
   (error) => {
     return Promise.reject(error);
   }
 );
+
+apiClient.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+  async (error) => {
+    const originalRequest = error.config;
+
+    if (error.response.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true; // Marca como uma tentativa de repetição
+
+      try {
+        // Tenta obter um novo token usando o refresh token
+        const refreshToken = localStorage.getItem('refreshToken');
+        const response = await axios.post('http://127.0.0.1:8000/api/token/refresh/', {
+          refresh: refreshToken,
+        });
+
+        const newAccessToken = response.data.access;
+        localStorage.setItem('accessToken', newAccessToken);
+        apiClient.defaults.headers.common['Authorization'] = `Bearer ${newAccessToken}`;
+
+        originalRequest.headers['Authorization'] = `Bearer ${newAccessToken}`;
+
+        return apiClient(originalRequest);
+
+      } catch (refreshError) {
+        console.error("Refresh token inválido ou expirado.", refreshError);
+        localStorage.removeItem('accessToken');
+        localStorage.removeItem('refreshToken');
+        window.location.href = '/login';
+        return Promise.reject(refreshError);
+      }
+    }
+    return Promise.reject(error);
+  }
+);
+
 export default apiClient;

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+
+interface ProtectedRouteProps {
+  children: React.ReactNode;
+}
+
+const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
+  const token = localStorage.getItem('accessToken');
+
+  if (!token) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return <>{children}</>;
+};
+
+export default ProtectedRoute;

--- a/frontend/src/components/services-table.tsx
+++ b/frontend/src/components/services-table.tsx
@@ -1,43 +1,50 @@
-export default function ServicesTable() {
+interface Service {
+  id: number;
+  name: string;
+  duration: number;
+  price: string;
+}
+
+// Função auxiliar para formatar a duração de minutos para horas/minutos
+const formatDuration = (minutes: number) => {
+  if (minutes < 60) {
+    return `${minutes} min`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const mins = minutes % 60;
+  return mins > 0 ? `${hours}h ${mins}min` : `${hours}h`;
+};
+
+export default function ServicesTable({ services }: { services: Service[] }) {
   return (
     <div className="w-full font-syne">
       <div className="grid grid-cols-2 lg:grid-cols-3 bg-gray-secondary/3 border-[0.5px] border-gray py-3">
-        <div className="text-center lg:text-start text-sm lg:text-base lg:pl-12 font-semibold">
-          Serviço
-        </div>
-
-        <div className="text-center font-semibold text-sm lg:text-base">
-          Duração
-        </div>
-
-        <div className="text-center font-semibold text-sm lg:text-base ">
-          Preço
-        </div>
+        <div className="text-center lg:text-start text-sm lg:text-base lg:pl-12 font-semibold">Serviço</div>
+        <div className="text-center font-semibold text-sm lg:text-base">Duração</div>
+        <div className="text-center font-semibold text-sm lg:text-base ">Preço</div>
       </div>
 
       <div className="h-1" />
 
-      <div className="bg-gray-tertiary/3 border-[0.5px] border-gray font-syne py-3 space-y-[29px] h-[367px] overflow-scroll">
-        <div className="grid grid-cols-2 lg:grid-cols-3 items-center">
-          <div className="pl-12 text-sm lg:text-base ">
-            Maquiagem para casamento
-          </div>
-
-          <div className="text-center text-sm lg:text-base">120 horas</div>
-
-          <div className="text-center text-sm lg:text-base">R$ 145,50</div>
-        </div>
-
-        <div className="grid grid-cols-2 lg:grid-cols-3 items-center">
-          <div className="pl-12 text-sm lg:text-base ">
-            Manutenção de unhas de gel
-          </div>
-
-          <div className="text-center text-sm lg:text-base">1 horas</div>
-
-          <div className="text-center text-sm lg:text-base">R$ 50,00</div>
-        </div>
-
+      <div className="bg-gray-tertiary/3 border-[0.5px] border-gray font-syne py-3 space-y-[29px] h-[367px] overflow-auto">
+        {services.length > 0 ? (
+          services.map((service) => (
+            <div
+              key={service.id} // Chave única para cada item da lista
+              className="grid grid-cols-2 lg:grid-cols-3 items-center"
+            >
+              <div className="pl-12 text-sm lg:text-base ">{service.name}</div>
+              <div className="text-center text-sm lg:text-base">
+                {formatDuration(service.duration)}
+              </div>
+              <div className="text-center text-sm lg:text-base">
+                R$ {service.price}
+              </div>
+            </div>
+          ))
+        ) : (
+          <p className="text-center pt-10">Nenhum serviço encontrado.</p>
+        )}
         <div className="h-5" />
       </div>
     </div>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,26 +2,34 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import { BrowserRouter as Router, Routes, Route } from "react-router";
+
+// Componentes e Páginas
 import Login from "./pages/login.tsx";
 import SignUp from "./pages/signup.tsx";
 import Appointment from "./pages/appointment.tsx";
-import Layout from "./ui/dashboard.tsx";
+import Layout from "./ui/dashboard.tsx"; 
 import Services from "./pages/services.tsx";
 import Team from "./pages/team.tsx";
 import CadasterAppointment from "./pages/cadaster-appointment.tsx";
 import CadasterService from "./pages/cadaster-service.tsx";
 import CadasterWorker from "./pages/cadaster-worker.tsx";
 import PageNotFound from "./pages/page-not-found.tsx";
+import ProtectedRoute from "./components/ProtectedRoute.tsx"; 
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <Router>
       <Routes>
         <Route path="/login" element={<Login />} />
-
         <Route path="/signup" element={<SignUp />} />
-
-        <Route path="/" element={<Layout />}>
+        <Route
+          path="/"
+          element={
+            <ProtectedRoute>
+              <Layout />
+            </ProtectedRoute>
+          }
+        >
           <Route index path="agendamentos" element={<Appointment />} />
           <Route path="servicos" element={<Services />} />
           <Route path="equipe" element={<Team />} />

--- a/frontend/src/pages/cadaster-service.tsx
+++ b/frontend/src/pages/cadaster-service.tsx
@@ -1,14 +1,81 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import Input from "../components/input";
 import Layout from "../ui/cadaster";
+import apiClient from "../api/api";
 
 export default function CadasterService() {
+  const [name, setName] = useState("");
+  const [duration, setDuration] = useState("");
+  const [price, setPrice] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setSuccess(null);
+
+    const durationInt = parseInt(duration, 10);
+    const priceFloat = parseFloat(price.replace(",", "."));
+
+    if (!name || isNaN(durationInt) || isNaN(priceFloat)) {
+      setError("Por favor, preencha todos os campos com valores válidos.");
+      return;
+    }
+
+    try {
+      await apiClient.post("/services/", {
+        name: name,
+        duration: durationInt,
+        price: priceFloat.toFixed(2),
+      });
+
+      setSuccess("Serviço cadastrado com sucesso!");
+      setTimeout(() => {
+        navigate("/servicos");
+      }, 1500);
+
+    } catch (err: unknown) { 
+      if (err instanceof Error) {
+        setError(`Erro ao cadastrar o serviço: ${err.message}`);
+      } else {
+        setError("Ocorreu um erro desconhecido ao cadastrar o serviço.");
+      }
+      console.error(err);
+    }
+  };
+
   return (
-    <Layout title="Cadastrar Novo Serviço" tableColumns="3">
-      <Input type="text" placeholder="Nome do Serviço" theme="black" />
-
-      <Input type="text" placeholder="Duração" theme="black" />
-
-      <Input type="text" placeholder="Preço" theme="black" />
+    <Layout title="Cadastrar Novo Serviço" tableColumns="3" onSubmit={handleSubmit}>
+      <Input
+        type="text"
+        placeholder="Nome do Serviço"
+        theme="black"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      />
+      <Input
+        type="text"
+        placeholder="Duração (em minutos)"
+        theme="black"
+        value={duration}
+        onChange={(e) => setDuration(e.target.value)}
+      />
+      <Input
+        type="text"
+        placeholder="Preço (ex: 160.00)"
+        theme="black"
+        value={price}
+        onChange={(e) => setPrice(e.target.value)}
+      />
+      
+      {/* Mensagens de feedback */}
+      <div className="lg:col-span-3">
+        {error && <p className="text-red-500 text-center mb-2">{error}</p>}
+        {success && <p className="text-green-500 text-center mb-2">{success}</p>}
+      </div>
     </Layout>
   );
 }

--- a/frontend/src/pages/services.tsx
+++ b/frontend/src/pages/services.tsx
@@ -1,11 +1,49 @@
+import { useState, useEffect } from "react";
 import NavButton from "../components/nav-button";
 import ServicesTable from "../components/services-table";
+import apiClient from "../api/api";
+
+interface Service {
+  id: number;
+  name: string;
+  duration: number; // Em minutos
+  price: string;
+}
 
 export default function Services() {
+  const [services, setServices] = useState<Service[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    // Função para buscar os dados da API
+    const fetchServices = async () => {
+      try {
+        const response = await apiClient.get('/services/');
+        setServices(response.data);
+      } catch (err) {
+        setError("Não foi possível carregar os serviços.");
+        console.error(err);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchServices();
+  }, []); // O array vazio [] garante que isso rode apenas uma vez
+
+  // Renderização condicional
+  if (isLoading) {
+    return <p className="text-center mt-10">Carregando serviços...</p>;
+  }
+
+  if (error) {
+    return <p className="text-center mt-10 text-red-500">{error}</p>;
+  }
+
   return (
     <>
-      <ServicesTable />
-
+      <ServicesTable services={services} />
       <NavButton path="/cadastrar-servico" text="Novo Serviço" />
     </>
   );

--- a/frontend/src/ui/cadaster.tsx
+++ b/frontend/src/ui/cadaster.tsx
@@ -5,10 +5,12 @@ export default function Layout({
   title,
   children,
   tableColumns = "2",
+  onSubmit,
 }: {
   title: string;
   children: React.ReactNode;
   tableColumns?: string;
+  onSubmit: (e: React.FormEvent) => void;
 }) {
   return (
     <div className="flex flex-col justify-center items-center gap-[27px]">
@@ -17,20 +19,20 @@ export default function Layout({
       </p>
 
       <form
-        action=""
+        onSubmit={onSubmit}
         className={clsx(
           "grid w-full gap-[27px]",
           tableColumns === "2" && "lg:grid-cols-2",
           tableColumns === "3" && "lg:grid-cols-3",
-          tableColumns === "4" && "lg:grid-cols-4",
+          tableColumns === "4" && "lg:grid-cols-4"
         )}
       >
         {children}
-      </form>
 
-      <div className="w-full lg:w-50 mr-auto">
-        <SubmitButton text="Cadastrar" theme="black" />
-      </div>
+        <div className="w-full lg:w-50 mr-auto">
+          <SubmitButton text="Cadastrar" theme="black" type="submit" />
+        </div>
+      </form>
     </div>
   );
 }


### PR DESCRIPTION
Descrição:
Este Pull Request introduz a funcionalidade completa de gerenciamento de Serviços, integrando as telas do frontend em React com a API segura do Django.

O objetivo principal é substituir as páginas estáticas de serviços por componentes dinâmicos que consomem e enviam dados reais para o banco de dados. Com esta implementação, os usuários administradores agora podem visualizar a lista de serviços existentes e cadastrar novos serviços através de um formulário com validações robustas e feedback claro.

O que foi feito:
Listagem de Serviços (/servicos):

O componente ServicesTable foi refatorado para ser dinâmico, recebendo a lista de serviços via props.

A página Services agora realiza uma chamada GET /api/services/ na montagem para buscar e exibir a lista atualizada de serviços do banco de dados.

Adicionado tratamento de estados de carregamento (loading) e erro para uma melhor experiência de usuário.

Cadastro de Novos Serviços (/cadastrar-servico):

A página CadasterService foi integrada com o endpoint POST /api/services/, permitindo a criação de novos serviços.

Implementada validação de formato no frontend com Expressões Regulares (Regex) para os campos de "Duração" e "Preço", bloqueando dados mal formatados antes de enviar para a API.

O componente de layout ui/cadaster foi aprimorado para ser mais reutilizável, aceitando as propriedades onSubmit e submitText.

Melhorias Gerais:

O tratamento de erros da API nos formulários foi aprimorado para extrair e exibir as mensagens de validação específicas que vêm do backend (ex: "serviço com este nome já existe."), em vez de erros genéricos.